### PR TITLE
Fix gradient from header for safari

### DIFF
--- a/src/Header.js
+++ b/src/Header.js
@@ -13,7 +13,7 @@ const HeaderStyled = styled.header`
   z-index: 100;
   background: linear-gradient(
     to top,
-    rgba(255, 255, 255, 0) 0%,
+    rgba(101, 198, 218, 0) 0%,
     rgba(101, 198, 218, 0.9) 20%,
     rgba(101, 198, 218) 70%
   );


### PR DESCRIPTION
Der erste Wert musste die selbe Farbe haben wie die anderen beiden, von 255,255,255 auf 101, 198, 218 gestellt.
Nun siehts gut aus...